### PR TITLE
Infra/tls cert

### DIFF
--- a/django/base/settings.py
+++ b/django/base/settings.py
@@ -12,27 +12,37 @@ Quick-start development settings - unsuitable for production
 """
 
 import os
+import environ
 from pathlib import Path
-
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# load environment variables from proper .env file
+if os.environ["DEPLOY_ENV"] == "prod":
+    environ.Env.read_env(os.path.join(BASE_DIR, ".env.webapp.prod"))
+else:
+    environ.Env.read_env(os.path.join(BASE_DIR, ".env.webapp"))
 
-ALLOWED_HOSTS = os.environ["ALLOWED_HOSTS"].split(" ")
-DEBUG = os.environ["DEBUG"]
-DEFAULT_AUTO_FIELD = os.environ["DEFAULT_AUTO_FIELD"]
-LANGUAGE_CODE = os.environ["LANGUAGE_CODE"]
-ROOT_URLCONF = os.environ["ROOT_URLCONF"]
-SECRET_KEY = os.environ["SECRET_KEY"]
-STATIC_URL = os.environ["STATIC_URL"]
-TIME_ZONE = os.environ["TIME_ZONE"]
-USE_I18N = os.environ["USE_I18N"]
-USE_TZ = os.environ["USE_TZ"]
-WSGI_APPLICATION = os.environ["WSGI_APPLICATION"]
-LOGIN_REDIRECT_URL = os.environ["LOGIN_REDIRECT_URL"]
-CRISPY_TEMPLATE_PACK = os.environ["CRISPY_TEMPLATE_PACK"]
-MEDIA_ROOT = os.path.join(BASE_DIR, os.environ["MEDIA_ROOT"])
-MEDIA_URL = os.environ["MEDIA_URL"]
+env = environ.Env(
+    # set casting, default value
+    DEBUG=(bool, False)
+)
+
+ALLOWED_HOSTS = env("ALLOWED_HOSTS").split(" ")
+DEBUG = env("DEBUG")
+DEFAULT_AUTO_FIELD = env("DEFAULT_AUTO_FIELD")
+LANGUAGE_CODE = env("LANGUAGE_CODE")
+ROOT_URLCONF = env("ROOT_URLCONF")
+SECRET_KEY = env("SECRET_KEY")
+STATIC_URL = env("STATIC_URL")
+TIME_ZONE = env("TIME_ZONE")
+USE_I18N = env("USE_I18N")
+USE_TZ = env("USE_TZ")
+WSGI_APPLICATION = env("WSGI_APPLICATION")
+LOGIN_REDIRECT_URL = env("LOGIN_REDIRECT_URL")
+CRISPY_TEMPLATE_PACK = env("CRISPY_TEMPLATE_PACK")
+MEDIA_ROOT = os.path.join(BASE_DIR, env("MEDIA_ROOT"))
+MEDIA_URL = env("MEDIA_URL")
 
 
 INSTALLED_APPS = [

--- a/infra/fargate/alb.tf
+++ b/infra/fargate/alb.tf
@@ -4,13 +4,14 @@ resource "aws_lb_target_group" "main" {
   protocol    = "HTTP"
   vpc_id      = var.vpc_id
   target_type = "ip"
-  # health_check {
-  #   path                = "/"
-  #   interval            = 30
-  #   timeout             = 5
-  #   healthy_threshold   = 2
-  #   unhealthy_threshold = 2
-  # }
+
+  health_check {
+    path                = "/"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
 }
 
 resource "aws_lb" "main" {
@@ -21,29 +22,30 @@ resource "aws_lb" "main" {
   subnets            = var.pub_subnet_ids
 }
 
-resource "aws_lb_listener" "main" {
+resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.main.arn
   port              = "80"
   protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  certificate_arn   = aws_acm_certificate.cert.arn
 
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.main.arn
   }
 }
-
-# create listener rule
-# resource "aws_lb_listener_rule" "main" {
-#   listener_arn = aws_lb_listener.main.arn
-#   priority     = 1
-#
-#   action {
-#     type             = "forward"
-#     target_group_arn = aws_lb_target_group.main.arn
-#   }
-#
-#   condition {
-#     field  = "path-pattern"
-#     values = ["/"]
-#   }
-# }

--- a/infra/fargate/main.tf
+++ b/infra/fargate/main.tf
@@ -147,6 +147,17 @@ resource "aws_ecs_task_definition" "main" {
           protocol      = "tcp"
         }
       ]
+      environment = [
+        {
+          name = "DEPLOY_ENV", value = "prod"
+        }
+      ]
+      # environmentFiles = [
+      #   {
+      #     value = "s3://my-bucket/ecs-env-files/django.env"
+      #     type  = "s3"
+      #   }
+      # ]
       command = [
         "gunicorn",
         "base.wsgi:application",


### PR DESCRIPTION
Done:
- added tls resources for domain, tied cert to alb
- added 80 redirect listener to 443
- reverted settings.py to environ pattern (best practice for Django)
- added env var via task_definition
- fixed vpc module nat gateway duplication

Next (infra):
- aws_rds_instance with postgres
- media & static enablement in prod via s3 backend
- GitHub action workflow
- sg ingress restriction during development
- autoscaling group
- Prometheus scrapper via nginx?

Next (application):
- DALLE-2 image generation model experimentation